### PR TITLE
Initiate the is_training variable

### DIFF
--- a/model/BIMPM.py
+++ b/model/BIMPM.py
@@ -105,7 +105,7 @@ class BIMPM(nn.Module):
         nn.init.constant(self.pred_fc2.bias, val=0)
 
     def dropout(self, v):
-        return F.dropout(v, p=self.args.dropout, training=self.training)
+        return F.dropout(v, p=self.args.dropout, training=self.args.is_training)
 
     def forward(self, **kwargs):
         # ----- Matching Layer -----

--- a/test.py
+++ b/test.py
@@ -88,6 +88,7 @@ if __name__ == '__main__':
         print('loading Quora data...')
         data = Quora(args)
 
+    setattr(args, 'is_training', False)
     setattr(args, 'char_vocab_size', len(data.char_vocab))
     setattr(args, 'word_vocab_size', len(data.TEXT.vocab))
     setattr(args, 'class_size', len(data.LABEL.vocab))

--- a/train.py
+++ b/train.py
@@ -128,6 +128,7 @@ def main():
     else:
         raise NotImplementedError('only SNLI or Quora data is possible')
 
+    setattr(args, 'is_training', True)
     setattr(args, 'char_vocab_size', len(data.char_vocab))
     setattr(args, 'word_vocab_size', len(data.TEXT.vocab))
     setattr(args, 'class_size', len(data.LABEL.vocab))


### PR DESCRIPTION
현재 BIMPM.py 파일의 dropout method는
```   
def dropout(self, v):
        return F.dropout(v, p=self.args.dropout, training=self.training)
```
위와 같이 self.training이라는 variable을 넘겨주고 있지만 이 variable은 어디서도 초기화되지 않습니다.
본래 training argument의 취지에 맞게 각 모드에 맞는 값을 초기화하고 args를 통해 넘겨주도록 했습니다.